### PR TITLE
GITHUB_TOKEN に Issues への read 権限を追加 #24

### DIFF
--- a/.github/workflows/copy-issues.yml
+++ b/.github/workflows/copy-issues.yml
@@ -79,6 +79,8 @@ jobs:
   get-myrepo-milestones:
     needs: create-milestones
     runs-on: ubuntu-latest
+    permissions:
+      issues: read
     outputs:
       milestones: ${{ steps.output_milestones_data.outputs.value }}
     steps:
@@ -118,6 +120,8 @@ jobs:
   get-myrepo-issues:
     if: github.repository != 'yumemi-inc/ios-engineer-codecheck'
     runs-on: ubuntu-latest
+    permissions:
+      issues: read
     outputs:
       issues: ${{ steps.output_issues_data.outputs.value }}
     steps:


### PR DESCRIPTION
GITHUB_TOKEN の issues に関する default permission が none になったので、 **private** repository の場合、以下が 403 になります。
https://docs.github.com/en/actions/security-guides/automatic-token-authentication

- get-myrepo-issues
- get-myrepo-milestones

## GitHub Actions Failure Result
<img width="347" alt="Screenshot 2023-05-14 at 0 51 10" src="https://github.com/ykws/android-engineer-codecheck/assets/5770480/f76b95f0-8852-423c-a793-6fa7e74fecca">

## Notes
- **public** repository の場合は、アクセス可能なため、 #21 の対応で十分になります。
- https://github.com/yumemi-inc/android-engineer-codecheck/pull/24 Android の方で問題に気づいて同じ対応をしました。